### PR TITLE
Changes for report generation between simba and deloitte

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-execution-tests/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-execution-tests/pom.xml
@@ -140,11 +140,13 @@
                             <dependency>
                                 <groupId>org.apache.maven.surefire</groupId>
                                 <artifactId>surefire-junit47</artifactId>
-                                <version>2.22.2</version></dependency>
+                                <version>3.1.2</version>
+                            </dependency>
                         </dependencies>
                         <!-- Without override, surefire configuration would have skipped our integration tests -->
                         <configuration combine.self="override">
-                            <useSystemClassLoader>false</useSystemClassLoader>
+                            <useSystemClassLoader>true</useSystemClassLoader>
+                            <useManifestOnlyJar>false</useManifestOnlyJar>
                             <trimStackTrace>false</trimStackTrace>
                             <argLine>${argLine} ${surefire.vm.params}</argLine>
                             <additionalClasspathElements>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-execution-tests/src/test/java/org/finos/legend/engine/server/test/pureClient/stores/dbSpecific/Test_Relational_DbSpecific_BigQuery_UsingPureClientTestSuite.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-bigquery/legend-engine-xt-relationalStore-bigquery-execution-tests/src/test/java/org/finos/legend/engine/server/test/pureClient/stores/dbSpecific/Test_Relational_DbSpecific_BigQuery_UsingPureClientTestSuite.java
@@ -21,13 +21,16 @@ import org.finos.legend.engine.server.test.shared.Relational_DbSpecific_UsingPur
 import org.finos.legend.pure.runtime.java.compiled.testHelper.IgnoreUnsupportedApiPureTestSuiteRunner;
 import org.junit.runner.RunWith;
 
+import java.util.TimeZone;
+
 @RunWith(IgnoreUnsupportedApiPureTestSuiteRunner.class)
 public class Test_Relational_DbSpecific_BigQuery_UsingPureClientTestSuite extends Relational_DbSpecific_UsingPureClientTestSuite
 {
     public static Test suite() throws Exception
     {
-        return createSuite(
-                "meta::relational::tests::sqlQueryToString::bigQuery",
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        assert TimeZone.getDefault().getID().equals("UTC");
+        return createSuite(                "meta::relational::tests::sqlQueryToString::bigQuery",
                 "org/finos/legend/engine/server/test/userTestConfig_withBigQueryTestConnection.json",
                 new NamedType(BigQueryTestDatabaseAuthenticationFlowProviderConfiguration.class, "bigQueryTest")
         );

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/src/main/java/org/finos/legend/engine/test/LegendDatabaseSQLTestingReport.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/src/main/java/org/finos/legend/engine/test/LegendDatabaseSQLTestingReport.java
@@ -123,10 +123,10 @@ public class LegendDatabaseSQLTestingReport
                     {
                         LegendDatabaseTestingReportGenerator.SQLTestSummary emptySummary = new LegendDatabaseTestingReportGenerator.SQLTestSummary();
                         TestStatus testStatus = summariesByDatabase.getOrDefault(db, emptySummary).getTestResult(testName);
-
-                        statusesByDatabase.putIfAbsent(db, Maps.mutable.empty());
-                        statusesByDatabase.get(db).putIfAbsent(testStatus, 0);
-                        statusesByDatabase.get(db).compute(testStatus, (ts, count) -> count + 1);
+                        String dbName = summariesByDatabase.get(db).database;
+                        statusesByDatabase.putIfAbsent(dbName, Maps.mutable.empty());
+                        statusesByDatabase.get(dbName).putIfAbsent(testStatus, 0);
+                        statusesByDatabase.get(dbName).compute(testStatus, (ts, count) -> count + 1);
 
                         return testStatus;
                     }
@@ -155,13 +155,7 @@ public class LegendDatabaseSQLTestingReport
 
     private String resolveDatabaseName(String database)
     {
-        Optional<DatabaseType> databaseType = ArrayIterate.detectOptional(DatabaseType.values(), type -> type.name().equals(database));
-        if (!databaseType.isPresent())
-        {
-            System.out.println("Report processing error. Unknown database type '" + database + "'");
-            return UNKNOWN_DATABASE;
-        }
-        return databaseType.get().name();
+        return database;
     }
 
     private ImmutableList<String> allDatabasesInSpecificOrder()
@@ -169,21 +163,16 @@ public class LegendDatabaseSQLTestingReport
         ImmutableList<DatabaseType> allDatabaseTypes = Lists.immutable.with(DatabaseType.values());
 
         // databases that we have tests for OR databases that are actively being used by Legend users OR databases that have convenient test doubles or test infrastructure
-        ImmutableList<DatabaseType> databaseSet1 = Lists.immutable.of(
-                DatabaseType.H2, DatabaseType.Postgres,
-                DatabaseType.SqlServer,
-                DatabaseType.Snowflake, DatabaseType.Databricks,
-                DatabaseType.BigQuery, DatabaseType.Spanner,
-                DatabaseType.MemSQL, DatabaseType.Presto,
-                DatabaseType.Redshift, DatabaseType.Athena);
+        ImmutableList<DatabaseType> databaseSet1 = Lists.immutable.of();
 
         // everything else
         ImmutableList<DatabaseType> databaseSet2 = allDatabaseTypes.reject(d -> databaseSet1.contains(d));
 
         MutableList<DatabaseType> rearranged = Lists.mutable.withAll(databaseSet1);
-        rearranged.addAllIterable(databaseSet2);
+//        rearranged.addAllIterable(databaseSet2);
 
         //return rearranged.collect(Enum::name).collect(String::toLowerCase).toImmutable();
-        return rearranged.collect(Enum::name).toImmutable();
+        ImmutableList<String> testNames = Lists.immutable.with(DatabaseType.BigQuery.name() + " (Deloitte)",DatabaseType.BigQuery.name() + " (Simba)");
+        return testNames;
     }
 }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/src/main/java/org/finos/legend/engine/test/LegendDatabaseTestingReportGenerator.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-reports/src/main/java/org/finos/legend/engine/test/LegendDatabaseTestingReportGenerator.java
@@ -42,8 +42,10 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /*
     This class generates a summary report of SQL tests.
@@ -123,6 +125,7 @@ public class LegendDatabaseTestingReportGenerator
                 return FileVisitResult.CONTINUE;
             }
             SQLTestSummary sqlTestSummary = processJunitXmlReport(this.builder, path.toFile().getAbsolutePath());
+            sqlTestSummary.database = sqlTestSummary.database + " (" + Arrays.stream(fileName.split("__")).collect(Collectors.toList()).get(1) + ")";
             sqlTestSummaries.add(sqlTestSummary);
             return FileVisitResult.CONTINUE;
         }

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-server/src/main/java/org/finos/legend/engine/server/test/shared/Relational_DbSpecific_UsingPureClientTestSuite.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-test-server/src/main/java/org/finos/legend/engine/server/test/shared/Relational_DbSpecific_UsingPureClientTestSuite.java
@@ -75,7 +75,7 @@ public abstract class Relational_DbSpecific_UsingPureClientTestSuite extends Tes
             else
             {
                 TestCase testCase = (TestCase) test;
-                wrappedSuite.addTest(new TestCase(testCase.getName())
+                wrappedSuite.addTest(new TestCase(dbSuiteName + "::" + testCase.getName())
                 {
                     @Override
                     protected void runTest() throws Throwable


### PR DESCRIPTION
- We have to make some changes for generating report between simba and deloitte
- In case you cannot build changes locally, download the zip file and extract contents
- In extracted contents run script file to generate a test summary
- Replace files under xmls for custom report generation

Note You might have to delete existing summary before generating new one from the 